### PR TITLE
Add Finnish translations

### DIFF
--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -1,0 +1,74 @@
+{
+    "extName": {
+        "message": "d3coder",
+        "description": "Name of the extension"
+    },
+    "extDescription": {
+        "message": "Enkoodaus/Dekoodaus laajennus usealle eri enkoodausmenetelmälle, kuten base64, rot13 tai unix aikaleimojen käännöksille.",
+        "description": "Short description of the extension"
+    },
+    "settings": {
+        "message": "asetukset",
+        "description": "Title of the settings dialog for the extension"
+    },
+    "message_type": {
+        "message": "Viestin Tyyppi",
+        "description": "How the converted text will be displayed"
+    },
+    "type_alert": {
+        "message": "Käytä alert() ilmoitusta",
+        "description": "Setting that enables the messages to be displayed in an alert box"
+    },
+    "type_console": {
+        "message": "Näytä lokit konsolissa",
+        "description": "Setting that enables the messages to be displayed in the JS console"
+    },
+    "type_html": {
+        "message": "Lisää HTML elementti sivuston pohjalle",
+        "description": "Setting that enables the messages to be displayed in a HTML element inserted into the page"
+    },
+    "type_inplace": {
+        "message": "Vaihda tekstit valittuun elementtiin",
+        "description": "Setting that enables the messages to be displayed as replacement of the original text"
+    },
+    "copy_results_to_clipboard": {
+        "message": "Kopioi tulokset leikepöydälle käännöksen jälkeen (huomaa, että tämä saattaa ylikirjoittaa leikepöydällä olevia tietoja, joten käytä varoen!)",
+        "description": "Label of the checkbox that enables clipboard-copy post-conversion in the settings"
+    },
+    "activate_functions": {
+        "message": "Aktivoi Funktioita",
+        "description": "Title of the part of the settings that (in)activates de/encoding functions"
+    },
+    "activate_functions_description": {
+        "message": "Voit määrittää mitä funktioita näytetään kontekstivalikossa.",
+        "description": "Description for the part of the settings that (in)activates de/encoding functions"
+    },
+    "function_timestamp": {
+        "message": "UNIX aikaleimojen kääännökset",
+        "description": "Function name for UNIX Timestamp conversion"
+    },
+    "function_htmlspecialchars": {
+        "message": "HTML erikoismerkkien enkoodaus",
+        "description": "Function name for HTML special chars encode"
+    },
+    "function_htmlspecialchars_decode": {
+        "message": "HTML erikoismerkkien dekoodaus",
+        "description": "Function name for HTML special chars decode"
+    },
+    "function_reverse_text": {
+        "message": "Käänteinen teksti",
+        "description": "Function name for Reverse Text"
+    },
+    "message_copied_to_clipboard": {
+        "message": "Viesti kopioitu leikepöydälle!",
+        "description": "message when text was successfully copied to the clipboard"
+    },
+    "copy_last_conversion_to_clipboard": {
+        "message": "Kopioi edellinen käännös leikepöydälle",
+        "description": ""
+    },
+    "options_saved": {
+        "message": "Asetukset tallennettu.",
+        "description": "Success message when the user settings where successfully saved"
+    }
+}


### PR DESCRIPTION
Add Finnish translations for the extension. Skipped self-explanatory things like "Base64 encode" -> "Base64 enkoodaus".

Related issue: #50 